### PR TITLE
Fixed occasional issue of bpy.context being NoneType.

### DIFF
--- a/SmartBoneDissolve.py
+++ b/SmartBoneDissolve.py
@@ -88,7 +88,7 @@ class ARMATURE_OT_smart_bone_dissolve(Operator):
                         mixmod.mix_mode = "ADD"
                         
                         # Exiting edit mode if currently in it
-                        if bpy.context.active_object.mode == "EDIT":
+                        if sel_arm.mode == "EDIT":
                             bpy.ops.object.editmode_toggle()
                         # Setting the mesh to be active object
                         mesh.select_set(True)


### PR DESCRIPTION
This happens when the object becomes deselected due to operations happening.
However, the context was already being held by sel_arm, so the mode can be checked off of that, before changing the mode on the ops object.